### PR TITLE
fix: use start value when restart sequences

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,14 +9,6 @@ parameters:
 	        count: 1
 	        path: ./src/DependencyInjection
 	    -
-	        message: '#Parameter \#2 ...\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given.#'
-	        count: 1
-	        path: ./src/Database/Manager/PostgreSQLDatabaseManager.php
-	    -
-	        message: '#Offset (.*)? does not exist on array\{(.*)?\}.#'
-	        count: 9
-	        path: ./src/Database/Manager/PostgreSQLDatabaseManager.php
-	    -
 	        message: '#Offset (.*)? does not exist on array\{(.*)?\}.#'
 	        count: 1
 	        path: ./src/Database/Manager/SqliteDatabaseManager.php

--- a/src/Database/Manager/PostgreSQLDatabaseManager.php
+++ b/src/Database/Manager/PostgreSQLDatabaseManager.php
@@ -45,10 +45,10 @@ class PostgreSQLDatabaseManager extends DatabaseManager
         }
 
         $databaseName = $this->getDatabaseName();
-        $password = $this->connection->getParams()['password'];
-        $user = $this->connection->getParams()['user'];
-        $host = $this->connection->getParams()['host'];
-        $port = $this->connection->getParams()['port'];
+        $password = $this->getConnectionParams()['password'];
+        $user = $this->getConnectionParams()['user'];
+        $host = $this->getConnectionParams()['host'];
+        $port = $this->getConnectionParams()['port'];
 
         # Needed for optimization
         $additionalParams = sprintf('--no-comments --disable-triggers --data-only -T %s', $this->migrationsTable);
@@ -82,10 +82,10 @@ class PostgreSQLDatabaseManager extends DatabaseManager
 
         $backupFilename = $this->getBackupFilename($fixtures);
         $databaseName = $this->getDatabaseName();
-        $password = $this->connection->getParams()['password'];
-        $user = $this->connection->getParams()['user'];
-        $host = $this->connection->getParams()['host'];
-        $port = $this->connection->getParams()['port'];
+        $password = $this->getConnectionParams()['password'];
+        $user = $this->getConnectionParams()['user'];
+        $host = $this->getConnectionParams()['host'];
+        $port = $this->getConnectionParams()['port'];
 
         $this->consoleManager->loadDump($backupFilename, $user, $host, $port, $databaseName, $password);
 
@@ -132,11 +132,12 @@ class PostgreSQLDatabaseManager extends DatabaseManager
         $sequences = $this->connection->executeQuery('SELECT * FROM information_schema.sequences')
             ->fetchAllAssociative();
 
+        /** @var array{sequence_name: string, start_value?: string} $sequence */
         foreach ($sequences as $sequence) {
             $this->connection->executeStatement(sprintf(
                 'ALTER SEQUENCE %s RESTART WITH %s',
                 $sequence['sequence_name'],
-                $sequence['start_value'] ?? 1
+                $sequence['start_value'] ?? '1'
             ));
         }
     }
@@ -174,6 +175,14 @@ class PostgreSQLDatabaseManager extends DatabaseManager
 
     protected function getDatabaseName(): string
     {
-        return $this->connection->getParams()['dbname'];
+        return $this->getConnectionParams()['dbname'];
+    }
+
+    private function getConnectionParams(): array
+    {
+        /** @var array{dbname: string, password: string, user: string, host: string, port: int} $connectionParams */
+        $connectionParams = $this->connection->getParams();
+
+        return $connectionParams;
     }
 }

--- a/src/Database/Manager/PostgreSQLDatabaseManager.php
+++ b/src/Database/Manager/PostgreSQLDatabaseManager.php
@@ -133,9 +133,11 @@ class PostgreSQLDatabaseManager extends DatabaseManager
             ->fetchAllAssociative();
 
         foreach ($sequences as $sequence) {
-            $this->connection->executeStatement(
-                sprintf('ALTER SEQUENCE %s RESTART WITH 1', $sequence['sequence_name'])
-            );
+            $this->connection->executeStatement(sprintf(
+                'ALTER SEQUENCE %s RESTART WITH %s',
+                $sequence['sequence_name'],
+                $sequence['start_value'] ?? 1
+            ));
         }
     }
 


### PR DESCRIPTION
Це потрібно у випадках коли дефолтне значення встановлене через SQL не дорівнює 1
`ALTER SEQUENCE my_seq START WITH 123`